### PR TITLE
Ditch obsolete redcarpet Markdown engine

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,6 @@ baseurl: "/style-guide" # the subpath of your site, e.g. /blog/
 url: "https://fieldaware.github.io" # the base hostname & protocol for your site
 
 # Build settings
-markdown: redcarpet
+markdown: kramdown
 redcarpet:
     extensions: [with_toc_data]


### PR DESCRIPTION
I got a warning from GitHub that `redcarpet` is deprecated hence this PR.